### PR TITLE
feat: add rps arg to command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ run-api-test:
 	./etz api --workers=3 --config=examples/api/secret.json --helpers=examples/api/api.yaml --duration=3s
 	./etz api --workers=10 --config=examples/api/secret.yaml --helpers=examples/api/api.json --duration=3s
 	./etz api --workers=100 --config=examples/api/secret.yaml --helpers=examples/api/api.yaml --duration=3s
-	./etz api --workers=10 --config=examples/api/secret.yaml --helpers=examples/api/api.json --duration=3s --rps=200
-	./etz api --workers=100 --config=examples/api/secret.yaml --helpers=examples/api/api.yaml --duration=3s -- rps=400
+	./etz api --workers=10 --config=examples/api/secret.yaml --helpers=examples/api/api.json --duration=10s --rps=200
+	./etz api --workers=100 --config=examples/api/secret.yaml --helpers=examples/api/api.yaml --duration=10s -- rps=400
 
 api-down:
 	cd examples/api && docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 #
 # all will run unit tests, build cli tool and run it with pgsql and api server
 all: go-test go-build pgsql-up sql-seed run-pgsql-test pgsql-down api-up api-seed run-api-test api-down 
-
 # go
 go-test:
 	go test -v ./...
@@ -24,9 +23,12 @@ sql-seed:
 
 run-pgsql-test:
 	./etz sql --workers=3 --config=examples/pgsql/secret.json --helpers=examples/pgsql/sql.csv --verbose
+	./etz sql --workers=3 --config=examples/pgsql/secret.json --helpers=examples/pgsql/sql.csv --verbose --rps=1
 	./etz sql --workers=3 --config=examples/pgsql/secret.json --helpers=examples/pgsql/sql.csv --duration=3s
 	./etz sql --workers=10 --config=examples/pgsql/secret.yaml --helpers=examples/pgsql/sql.csv --duration=3s
 	./etz sql --workers=100 --config=examples/pgsql/secret.yaml --helpers=examples/pgsql/sql.csv --duration=3s
+	./etz sql --workers=10 --config=examples/pgsql/secret.yaml --helpers=examples/pgsql/sql.csv --duration=10s --rps=5
+	./etz sql --workers=100 --config=examples/pgsql/secret.yaml --helpers=examples/pgsql/sql.csv --duration=10s --rps=10
 
 pgsql-down:
 	cd examples/pgsql && docker-compose down
@@ -45,9 +47,12 @@ api-seed:
 
 run-api-test:
 	./etz api --workers=3 --config=examples/api/secret.json --helpers=examples/api/api.json --verbose
+	./etz api --workers=3 --config=examples/api/secret.json --helpers=examples/api/api.json --verbose --rps=1
 	./etz api --workers=3 --config=examples/api/secret.json --helpers=examples/api/api.yaml --duration=3s
 	./etz api --workers=10 --config=examples/api/secret.yaml --helpers=examples/api/api.json --duration=3s
 	./etz api --workers=100 --config=examples/api/secret.yaml --helpers=examples/api/api.yaml --duration=3s
+	./etz api --workers=10 --config=examples/api/secret.yaml --helpers=examples/api/api.json --duration=3s --rps=200
+	./etz api --workers=100 --config=examples/api/secret.yaml --helpers=examples/api/api.yaml --duration=3s -- rps=400
 
 api-down:
 	cd examples/api && docker-compose down

--- a/cli/cmd/api.go
+++ b/cli/cmd/api.go
@@ -26,7 +26,7 @@ func benchmarkAPI(cmd *cobra.Command, args []string) {
 		logger.Fatal("could set job duration")
 	}
 
-	s, err := scheduler.NewScheduler(logger, jobDuration, "api", configFile, helpersFile, workersCount, Verbose)
+	s, err := scheduler.NewScheduler(logger, jobDuration, "api", configFile, helpersFile, rps, workersCount, Verbose)
 	if err != nil {
 		logger.Fatal("could not create a scheduler instance")
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -46,6 +46,7 @@ func init() {
 	sqlCmd.PersistentFlags().StringVar(&seedFile, "seed", "../../files/seed.sql", "prepare sql instance")
 
 	rootCmd.PersistentFlags().StringVar(&duration, "duration", "", "job duration")
+	rootCmd.PersistentFlags().IntVar(&rps, "rps", 0, "how many requests per second should be executed during the job")
 	rootCmd.PersistentFlags().IntVar(&workersCount, "workers", 1, "workers to run the job")
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", "../../files/config.json", "config file location")
 	rootCmd.PersistentFlags().StringVar(&helpersFile, "helpers", "../../files/helpers.csv", "helpers file location")

--- a/cli/cmd/sql.go
+++ b/cli/cmd/sql.go
@@ -26,7 +26,7 @@ func benchmarkSql(cmd *cobra.Command, args []string) {
 		logger.Fatal("could set job duration")
 	}
 
-	s, err := scheduler.NewScheduler(logger, jobDuration, "sql", configFile, helpersFile, workersCount, Verbose)
+	s, err := scheduler.NewScheduler(logger, jobDuration, "sql", configFile, helpersFile, rps, workersCount, Verbose)
 	if err != nil {
 		logger.Fatal("could not create a scheduler instance")
 	}

--- a/roles/scheduler/duration.go
+++ b/roles/scheduler/duration.go
@@ -131,13 +131,3 @@ func concatAllDurations(assignmentResults map[string][]time.Duration) []time.Dur
 	}
 	return allDurations
 }
-
-// setRps
-func (s *Scheduler) setRps() time.Duration {
-	var rpsSleepInDurationLoop time.Duration
-	if s.jobRps == 0 {
-		return rpsSleepInDurationLoop
-	}
-	rpsSleepInDurationLoop = time.Duration(int64(1000/s.jobRps) * 1000000)
-	return rpsSleepInDurationLoop
-}

--- a/roles/scheduler/duration.go
+++ b/roles/scheduler/duration.go
@@ -48,7 +48,7 @@ func (s *Scheduler) ExecuteJobByDuration() (*Result, error) {
 		}(i)
 	}
 
-	go addToWorkChannel(s.jobDuration, s.tasksChan, assignments)
+	go addToWorkChannel(s.setRps(), s.jobDuration, s.tasksChan, assignments)
 
 	go func() {
 		wg.Wait()
@@ -75,7 +75,7 @@ func (s *Scheduler) ExecuteJobByDuration() (*Result, error) {
 }
 
 // addToWorkChannel will add assignments to work channel and close the channel when the duration time is over
-func addToWorkChannel(duration time.Duration, c chan worker.Assignment, assigments []worker.Assignment) {
+func addToWorkChannel(sleepTime, duration time.Duration, c chan worker.Assignment, assigments []worker.Assignment) {
 	defer wg.Done()
 	timer := time.NewTimer(duration)
 
@@ -90,6 +90,7 @@ func addToWorkChannel(duration time.Duration, c chan worker.Assignment, assigmen
 			return
 		default:
 			for _, a := range assigments {
+				time.Sleep(sleepTime)
 				c <- a
 			}
 		}
@@ -129,4 +130,14 @@ func concatAllDurations(assignmentResults map[string][]time.Duration) []time.Dur
 		}
 	}
 	return allDurations
+}
+
+// setRps
+func (s *Scheduler) setRps() time.Duration {
+	var rpsSleepInDurationLoop time.Duration
+	if s.jobRps == 0 {
+		return rpsSleepInDurationLoop
+	}
+	rpsSleepInDurationLoop = time.Duration(int64(1000/s.jobRps) * 1000000)
+	return rpsSleepInDurationLoop
 }

--- a/roles/scheduler/scheduler.go
+++ b/roles/scheduler/scheduler.go
@@ -59,6 +59,20 @@ func NewScheduler(logger *zlog.Logger, duration time.Duration, executionType, co
 }
 
 //
+// -------------------------------------------------------------------------------------------- scheduling work channel --------------------------------------------------------------------------------------------------------------
+//
+
+// setRps returns a duration to sleep (in a second timeframe) that will set the amount of requests per seconds later during job execution
+func (s *Scheduler) setRps() time.Duration {
+	var rpsSleepInDurationLoop time.Duration
+	if s.jobRps == 0 {
+		return rpsSleepInDurationLoop
+	}
+	rpsSleepInDurationLoop = time.Duration(int64(1000/s.jobRps) * 1000000)
+	return rpsSleepInDurationLoop
+}
+
+//
 // --------------------------------------------------------------------------------------------- worker assignments -----------------------------------------------------------------------------------------------------------------
 //
 

--- a/roles/scheduler/scheduler.go
+++ b/roles/scheduler/scheduler.go
@@ -29,7 +29,7 @@ type Scheduler struct {
 	// jobDuration is how long the command should run (30s, 1m etc)
 	jobDuration time.Duration
 	// jobRps define the frequency for api requests or sql queries during the job execution
-	jobRps int
+	jobRps int64
 	// tasksOrder defined by api request or sql query weight. The weight cann be defined in the config file and order tasks in the worker assignment channel by calculating the weight of each task
 	tasksOrder []int
 	// ExecutionType from command line arg can be sql, api or other type of executions
@@ -43,12 +43,13 @@ type Scheduler struct {
 }
 
 // NewScheduler creates an instance of a Scheduler
-func NewScheduler(logger *zlog.Logger, duration time.Duration, executionType, configFile, helperFile string, workers int, verbose bool) (*Scheduler, error) {
+func NewScheduler(logger *zlog.Logger, duration time.Duration, executionType, configFile, helperFile string, rps, workers int, verbose bool) (*Scheduler, error) {
 	return &Scheduler{
 		Logger:          logger,
 		tasksChan:       make(workerChannel, workers),
 		resultsChan:     make(chan time.Duration),
 		jobDuration:     duration,
+		jobRps:          int64(rps),
 		ExecutionType:   executionType,
 		ConfigFile:      configFile,
 		HelpersFile:     helperFile,

--- a/roles/scheduler/scheduler_test.go
+++ b/roles/scheduler/scheduler_test.go
@@ -6,7 +6,34 @@ import (
 
 	"github.com/nadavbm/etzba/roles/sqlclient"
 	"github.com/nadavbm/etzba/roles/worker"
+	"github.com/nadavbm/zlog"
 )
+
+func TestRpsSet(t *testing.T) {
+	logger := zlog.New()
+	duration := time.Duration(3 * time.Second)
+	s, err := NewScheduler(logger, duration, "api", "secret.json", "api.yaml", 10, 2, true)
+	if err != nil {
+		t.Fatal("could not create scheduler instance")
+	}
+
+	rps := s.setRps()
+	if rps != time.Duration(100*time.Millisecond) {
+		t.Errorf("expected rps to be 100ms but instead got %v", rps)
+	}
+
+	s.jobRps = 200
+	rps = s.setRps()
+	if rps != time.Duration(5*time.Millisecond) {
+		t.Errorf("expected rps to be 100ms but instead got %v", rps)
+	}
+
+	s.jobRps = 50
+	rps = s.setRps()
+	if rps != time.Duration(20*time.Millisecond) {
+		t.Errorf("expected rps to be 100ms but instead got %v", rps)
+	}
+}
 
 func TestAppendAssignmentDurationsToConcatDurations(t *testing.T) {
 	sqlQueries := []sqlclient.QueryBuilder{

--- a/roles/scheduler/task_completion.go
+++ b/roles/scheduler/task_completion.go
@@ -59,8 +59,10 @@ func (s *Scheduler) ExecuteJobUntilCompletion() (*Result, error) {
 	}()
 
 	// Send work to be done
+	rpsSleepTime := s.setRps()
 	go func() {
 		for _, a := range assignments {
+			time.Sleep(rpsSleepTime)
 			workCh <- a
 		}
 		close(workCh)


### PR DESCRIPTION
Add the ability to set request per seconds via command line.
The command can run like this:
```	
./etz api --workers=3 --config=examples/api/secret.json --helpers=examples/api/api.json --verbose --rps=1
./etz api --workers=10 --config=examples/api/secret.yaml --helpers=examples/api/api.json --duration=3s --rps=200
./etz api --workers=100 --config=examples/api/secret.yaml --helpers=examples/api/api.yaml --duration=3s -- rps=400

```